### PR TITLE
Add ci auto publish java and fix ci auto publish js

### DIFF
--- a/.github/workflows/auto-bump-up.yml
+++ b/.github/workflows/auto-bump-up.yml
@@ -81,3 +81,4 @@ jobs:
           branch: auto-bump-up/${{ env.NEW_TAG }}
           labels: automated pr
           title: bump up finschia ${{ env.NEW_TAG }} into main
+          base: main

--- a/.github/workflows/auto-bump-up.yml
+++ b/.github/workflows/auto-bump-up.yml
@@ -55,7 +55,7 @@ jobs:
         if: env.NEW_TAG
         run: |
           echo '# Choose from https://github.com/Finschia/finschia/releases' | cat > env
-          echo FINSCHIA_SKD_VERSION=${{ env.FINSCHIA_SDK_VERSION }} | cat >> env
+          echo FINSCHIA_SDK_VERSION=${{ env.FINSCHIA_SDK_VERSION }} | cat >> env
           echo WASMD_VERSION=${{ env.WASMD_VERSION }} | cat >> env
           echo IBC_GO_VERSION=${{ env.IBC_GO_VERSION }} | cat >> env
 

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -3,8 +3,8 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
-      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0.0-rc1, v20.15.10-rc5
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -1,0 +1,41 @@
+name: Publish package to Maven Central Repository
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+
+      - name: Import signing key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        with:
+          gpg_private_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+          passphrase: ${{ secrets.OSSRH_PHRASE }}
+
+      - name: List keys
+        run: gpg -K
+
+      - name: Publish to maven
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PW: ${{ secrets.OSSRH_PW }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_PASSPHRASE }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          echo $RELEASE_VERSION
+          ./gradlew publish -DVERSION=$RELEASE_VERSION

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -28,13 +28,18 @@ jobs:
           yarn install
 
       - name: Build
-        run: yarn run build
+        run: |
+          cd js
+          yarn run build
 
       - name: Prepare publish
-        run: yarn prepare
+        run: |
+          cd js
+          yarn prepare
 
       - name: Check if tag and version match
         run: |
+          cd js
           if [ "$(git tag --points-at ${{ github.sha }})" == "v$(jq -r .version package.json)" ]; then
             echo "Tag and version match. Proceeding with publish."
           else
@@ -43,6 +48,8 @@ jobs:
           fi
 
       - name: Publish to NPM
-        run: npm publish
+        run: |
+          cd js
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -11,6 +11,8 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./js
     steps:
       - uses: actions/checkout@v3
 
@@ -22,24 +24,22 @@ jobs:
       - run: if [ ! -x "$(command -v yarn)" ]; then npm install -g yarn; fi
 
       - name: Install dependencies
+        working-directory: ${{ env.working-directory }}
         run: |
-          cd js
           yarn cache clean --all
           yarn install
 
       - name: Build
-        run: |
-          cd js
-          yarn run build
+        working-directory: ${{ env.working-directory }}
+        run: yarn run build
 
       - name: Prepare publish
-        run: |
-          cd js
-          yarn prepare
+        working-directory: ${{ env.working-directory }}
+        run: yarn prepare
 
       - name: Check if tag and version match
+        working-directory: ${{ env.working-directory }}
         run: |
-          cd js
           if [ "$(git tag --points-at ${{ github.sha }})" == "v$(jq -r .version package.json)" ]; then
             echo "Tag and version match. Proceeding with publish."
           else
@@ -48,8 +48,7 @@ jobs:
           fi
 
       - name: Publish to NPM
-        run: |
-          cd js
-          npm publish
+        working-directory: ${{ env.working-directory }}
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -2,8 +2,8 @@ name: Publish to NPM
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
-      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0.0-rc1, v20.15.10-rc5
   release:
     types: [released]
 

--- a/java/app/build.gradle.kts
+++ b/java/app/build.gradle.kts
@@ -109,21 +109,21 @@ tasks.javadoc {
     }
 }
 
-val groupIdVal = "io.github.finschia"
-val artifactIdVal = "finschia-proto"
-val versionVal: String? = System.getProperty("VERSION")
-
-val pomName = "finschia"
-val pomDesc = artifactIdVal
-val pomUrl = "https://github.com/Finschia/finschia-proto"
-val pomScmConnection = "scm:git:git://github.com/Finschia/finschia-proto.git"
-val pomDeveloperConnection = "scm:git:ssh://github.com/Finschia/finschia-proto.git"
-val pomScmUrl = "https://github.com/Finschia/finschia-proto"
-
-val ossrhUserName = System.getenv("OSSRH_USERNAME")
-val ossrhPassword = System.getenv("OSSRH_PW")
-
 publishing {
+    val groupIdVal = "io.github.finschia"
+    val artifactIdVal = "finschia-proto"
+    val versionVal: String? = System.getProperty("VERSION")
+
+    val pomName = "finschia"
+    val pomDesc = artifactIdVal
+    val pomUrl = "https://github.com/Finschia/finschia-proto"
+    val pomScmConnection = "scm:git:git://github.com/Finschia/finschia-proto.git"
+    val pomDeveloperConnection = "scm:git:ssh://github.com/Finschia/finschia-proto.git"
+    val pomScmUrl = "https://github.com/Finschia/finschia-proto"
+
+    val ossrhUserName = System.getenv("OSSRH_USERNAME")
+    val ossrhPassword = System.getenv("OSSRH_PW")
+
     publications {
         create<MavenPublication>("mavenJava") {
             groupId = groupIdVal

--- a/java/app/build.gradle.kts
+++ b/java/app/build.gradle.kts
@@ -14,6 +14,9 @@ plugins {
 
     id("com.google.protobuf")
     id("distribution")
+
+    `maven-publish`
+    signing
 }
 
 repositories {
@@ -93,4 +96,81 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
+}
+
+java{
+    withJavadocJar()
+    withSourcesJar()
+}
+
+tasks.javadoc {
+    if (JavaVersion.current().isJava8Compatible) {
+        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    }
+}
+
+val groupIdVal = "io.github.finschia"
+val artifactIdVal = "finschia-proto"
+val versionVal: String? = System.getProperty("VERSION")
+
+val pomName = "finschia"
+val pomDesc = artifactIdVal
+val pomUrl = "https://github.com/Finschia/finschia-proto"
+val pomScmConnection = "scm:git:git://github.com/Finschia/finschia-proto.git"
+val pomDeveloperConnection = "scm:git:ssh://github.com/Finschia/finschia-proto.git"
+val pomScmUrl = "https://github.com/Finschia/finschia-proto"
+
+val ossrhUserName = System.getenv("OSSRH_USERNAME")
+val ossrhPassword = System.getenv("OSSRH_PW")
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            groupId = groupIdVal
+            artifactId = artifactIdVal
+            version = versionVal?.substring(1) // without v
+ 
+            from(components["java"])
+            pom {
+                name.set(pomName)
+                description.set(pomDesc)
+                url.set(pomUrl)
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("dev")
+                        name.set("dev")
+                        email.set("dev@finschia.org")
+                    }
+                }
+                scm {
+                    connection.set(pomScmConnection)
+                    developerConnection.set(pomDeveloperConnection)
+                    url.set(pomScmUrl)
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "OSSRH"
+            url = uri("https://s01.oss.sonatype.org/content/repositories/releases/")
+            credentials {
+                username = ossrhUserName
+                password = ossrhPassword
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["mavenJava"])
 }


### PR DESCRIPTION
I tested `ci auto publish js` workflow with my forked repo and I found there are some errors.
errors were about building js from wrong directory.
so I set working directory to js folder.

I added auto publish java ci.