### PR TITLE
ci: fix for pub-java ci

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -37,5 +37,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_PASSPHRASE }}
           RELEASE_VERSION: ${{ github.ref_name }}
         run: |
-          echo $RELEASE_VERSION
+          cd java
           ./gradlew publish -DVERSION=$RELEASE_VERSION

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -4,8 +4,6 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0.0-rc1, v20.15.10-rc5
-  release:
-    types: [released]
 
 jobs:
   publish:

--- a/java/app/build.gradle.kts
+++ b/java/app/build.gradle.kts
@@ -7,7 +7,7 @@ import org.gradle.api.JavaVersion.VERSION_1_8
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    id("org.jetbrains.kotlin.jvm") version "1.5.10"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -25,16 +25,6 @@ repositories {
 }
 
 dependencies {
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    }
-
-    // Align versions of all Kotlin components
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-
-    // Use the Kotlin JDK 8 standard library.
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-
     api(libs.grpc.protobuf)
     api(libs.grpc.kotlin.stub)
     api(libs.grpc.stub)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* For java proto
  * Fix for ci of java-publish
  * Downgrade kotlin version from 1.8 to 1.5 for client who is not using latest kotlin version
  * Remove some unnecessary dependencies for proto maven-publish
* For js publish
  * Remove github action event handler for a release event