### PR TITLE
fix: For debugging, run with `bash -xe build.sh`

### DIFF
--- a/.github/workflows/auto-bump-up.yml
+++ b/.github/workflows/auto-bump-up.yml
@@ -69,7 +69,7 @@ jobs:
         if: env.NEW_TAG
         run: |
           chmod +x ./build.sh
-          ./build.sh
+          bash -xe build.sh
 
       - name: Install Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Since action fails in `build.sh`, run it with `-xe` to get a detailed execution log of `build.sh`.